### PR TITLE
Fix for PHP 5.4 error

### DIFF
--- a/src/Baikal/ModelBundle/Entity/Event.php
+++ b/src/Baikal/ModelBundle/Entity/Event.php
@@ -291,7 +291,8 @@ class Event
     public function getVObject() {
         if(is_null($this->vobject)) {
             
-            if(empty($this->getCalendardata())) {
+            $calendarData = $this->getCalendardata();
+            if(empty($calendarData)) {
                 $this->vobject = new VObject\Component\VCalendar();
                 $this->vobject->add('VEVENT', [
                     'SUMMARY' => 'Empty',
@@ -301,7 +302,7 @@ class Event
                 $this->setCalendardata($this->vobject->serialize());
             }
 
-            $this->vobject = VObject\Reader::read($this->getCalendardata());
+            $this->vobject = VObject\Reader::read($calendarData);
         }
 
         return $this->vobject;


### PR DESCRIPTION
 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Can't use method return value in write context in /home/default/br0ken.de/htdocs/baikal/Baikal/src/Baikal/ModelBundle/Entity/Event.php on line 294