### PR TITLE
Remove PROJECT_PACKAGE constant.

### DIFF
--- a/Core/Distrib.php
+++ b/Core/Distrib.php
@@ -26,4 +26,3 @@
 
 define("BAIKAL_VERSION", "0.3.0");
 define("BAIKAL_HOMEPAGE", "http://baikal-server.com");
-define("PROJECT_PACKAGE", "regular");

--- a/Core/Frameworks/Baikal/Model/Config/Distrib.php
+++ b/Core/Frameworks/Baikal/Model/Config/Distrib.php
@@ -37,17 +37,12 @@ class Distrib extends \Baikal\Model\Config {
 			"type" => "string",
 			"comment" => "The URL to the project homepage",
 		),
-		"PROJECT_PACKAGE" => array(
-			"type" => "string",
-			"comment" => "The type of the current package (one of 'flat', 'regular')"
-		),
 	);
 	
 	# Default values
 	protected $aData = array(
 		"BAIKAL_VERSION" => "",
 		"BAIKAL_HOMEPAGE" => "",
-		"PROJECT_PACKAGE" => "",
 	);
 	
 	public function formMorphologyForThisModelInstance() {

--- a/Core/Frameworks/BaikalAdmin/Controller/Dashboard.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/Dashboard.php
@@ -34,7 +34,6 @@ class Dashboard extends \Flake\Core\Controller {
 	public function render() {
 		$oView = new \BaikalAdmin\View\Dashboard();
 		$oView->setData("BAIKAL_VERSION", BAIKAL_VERSION);
-		$oView->setData("PROJECT_PACKAGE", PROJECT_PACKAGE);
 		
 		# Services status
 		$oView->setData("BAIKAL_CAL_ENABLED", BAIKAL_CAL_ENABLED);

--- a/Core/Frameworks/BaikalAdmin/Resources/Templates/Dashboard.html
+++ b/Core/Frameworks/BaikalAdmin/Resources/Templates/Dashboard.html
@@ -15,7 +15,7 @@
 		<div class="span3">
 			<h2>Version</h2>
 			<p>This systems runs<br />
-				Baïkal <span class="label label-info label-intext">{{ BAIKAL_VERSION }}</span>, <em>{{ PROJECT_PACKAGE }}</em> package<br />
+				Baïkal <span class="label label-info label-intext">{{ BAIKAL_VERSION }}</span>
 				<small><a href="{{ url }}">{{ url }}</a></small>
 			</p>
 		</div>

--- a/Core/Frameworks/Flake/Framework.php
+++ b/Core/Frameworks/Flake/Framework.php
@@ -154,13 +154,7 @@ class Framework extends \Flake\Core\Framework {
 
 		require_once(PROJECT_PATH_CORE . "Distrib.php");
 
-		if(PROJECT_PACKAGE === "regular") {
-			define("PROJECT_PATH_DOCUMENTROOT", PROJECT_PATH_ROOT . "html/");
-		} elseif(PROJECT_PACKAGE === "flat") {
-			define("PROJECT_PATH_DOCUMENTROOT", PROJECT_PATH_ROOT);
-		} else {
-			throw new \Exception("Unrecognized PROJECT_PACKAGE value.");
- 		}
+        define("PROJECT_PATH_DOCUMENTROOT", PROJECT_PATH_ROOT . "html/");
 
 		# Determine PROJECT_BASEURI
 		$sScript = substr($_SERVER["SCRIPT_FILENAME"], strlen($_SERVER["DOCUMENT_ROOT"]));


### PR DESCRIPTION
This constant is no longer needed because there will only be one package type in the future.
In the past it only controlled the 'docroot'. If we do need a way to configure this again,
we'll take a slightly different approach.

Ready for review & merge @netgusto 