### PR TITLE
renamed last ctag-fields to synctoken

### DIFF
--- a/Core/Frameworks/Baikal/Model/User.php
+++ b/Core/Frameworks/Baikal/Model/User.php
@@ -149,7 +149,7 @@ class User extends \Flake\Core\Model\Db {
 				"uri",
 				"default"
 			)->set(
-				"ctag",
+				"synctoken",
 				1
 			)->set(
 				"description",

--- a/Core/Frameworks/BaikalAdmin/Controller/User/AddressBooks.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/User/AddressBooks.php
@@ -146,7 +146,7 @@ class AddressBooks extends \Flake\Core\Controller {
 		);
 		
 		$this->oModel->set(
-			"ctag",
+			"synctoken",
 			"1"
 		);
 		

--- a/Core/Frameworks/BaikalAdmin/Controller/User/Calendars.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/User/Calendars.php
@@ -146,7 +146,7 @@ class Calendars extends \Flake\Core\Controller {
 		);
 		
 		$this->oModel->set(
-			"ctag",
+			"synctoken",
 			"1"
 		);
 		


### PR DESCRIPTION
Not all fields have been renamed from ctag to synctoken with the previous commit 50d96b4482d7478e099e5ea33380e3f9934d824a.
This caused some errors like this when creating a new calendar:

> exception 'Exception' with message '\Flake\Core\Model->set(): property ctag does not exist on Baikal\Model\AddressBook' in /var/www/baikal/Core/Frameworks/Flake/Core/Model.php:63
> Stack trace:
> #0 /var/www/baikal/Core/Frameworks/BaikalAdmin/Controller/User/AddressBooks.php(151): Flake\Core\Model->set('ctag', '1')
> #1 /var/www/baikal/Core/Frameworks/BaikalAdmin/Controller/User/AddressBooks.php(45): BaikalAdmin\Controller\User\AddressBooks->actionNew()
> #2 /var/www/baikal/Core/Frameworks/Flake/Core/Render/Container.php(62): BaikalAdmin\Controller\User\AddressBooks->execute()
> #3 /var/www/baikal/Core/Frameworks/Flake/Controller/Page.php(82): Flake\Core\Render\Container->execute()
> #4 /var/www/baikal/Core/Frameworks/BaikalAdmin/WWWRoot/index.php(81): Flake\Controller\Page->render()
> #5 {main}

This commit renames the last missing 'ctag' references and fixes the error above.


Thanks for merging ;-)
Pfuender