### PR TITLE
Remove ENABLE_INSTALL / ENABLE_ADMIN features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,8 @@
 logs
 
 # Specific
-Specific/ENABLE_ADMIN
 Specific/config.php
 Specific/config.system.php
-Specific/virtualhosts/baikal.apache2
 
 # Composer stuff
 composer.lock

--- a/Core/Distrib.php
+++ b/Core/Distrib.php
@@ -24,5 +24,5 @@
 #  This copyright notice MUST APPEAR in all copies of the script!
 #################################################################
 
-define("BAIKAL_VERSION", "0.3.4");
+define("BAIKAL_VERSION", "0.4.0");
 define("BAIKAL_HOMEPAGE", "http://baikal-server.com");

--- a/Core/Frameworks/Baikal/Model/Config/Standard.php
+++ b/Core/Frameworks/Baikal/Model/Config/Standard.php
@@ -45,14 +45,6 @@ class Standard extends \Baikal\Model\Config {
 			"type" => "string",
 			"comment" => "HTTP authentication type for WebDAV; default Digest"
 		),
-		"BAIKAL_ADMIN_ENABLED" => array(
-			"type" => "boolean",
-			"comment" => "Baïkal Web Admin ON/OFF switch; default TRUE",
-		),
-		"BAIKAL_ADMIN_AUTOLOCKENABLED" => array(
-			"type" => "boolean",
-			"comment" => "Baïkal Web Admin autolock ON/OFF switch; default FALSE",
-		),
 		"BAIKAL_ADMIN_PASSWORDHASH" => array(
 			"type" => "string",
 			"comment" => "Baïkal Web admin password hash; Set via Baïkal Web Admin",
@@ -65,8 +57,6 @@ class Standard extends \Baikal\Model\Config {
 		"BAIKAL_CARD_ENABLED" => TRUE,
 		"BAIKAL_CAL_ENABLED" => TRUE,
 		"BAIKAL_DAV_AUTH_TYPE" => "Digest",
-		"BAIKAL_ADMIN_ENABLED" => TRUE,
-		"BAIKAL_ADMIN_AUTOLOCKENABLED" => FALSE,
 		"BAIKAL_ADMIN_PASSWORDHASH" => ""
 	);
 	
@@ -117,24 +107,6 @@ class Standard extends \Baikal\Model\Config {
 			$oMorpho->element("BAIKAL_ADMIN_PASSWORDHASH")->setOption("placeholder", $sNotice);
 			$oMorpho->element("BAIKAL_ADMIN_PASSWORDHASH_CONFIRM")->setOption("placeholder", $sNotice);
 		}
-
-		$oMorpho->add(new \Formal\Element\Checkbox(array(
-			"prop" => "BAIKAL_ADMIN_ENABLED",
-			"label" => "Enable Web interface (recommended)",
-			"popover" => array(
-				"title" => "Warning !",
-				"content" => "If disabled, you'll lose access to this very admin interface !",
-			),
-		)));
-		
-		$oMorpho->add(new \Formal\Element\Checkbox(array(
-			"prop" => "BAIKAL_ADMIN_AUTOLOCKENABLED",
-			"label" => "Web interface autolock",
-			"popover" => array(
-				"title" => "Web admin autolock",
-				"content" => "If enabled, you'll have to create a file named <strong>ENABLE_ADMIN</strong> in the folder <strong>Specific/</strong> prior to every admin use.<br /><br />This enforces security, but might be uncomfortable if you use the admin frequently."
-			)
-		)));
 		
 		return $oMorpho;
 	}
@@ -206,12 +178,6 @@ define("BAIKAL_CAL_ENABLED", TRUE);
 
 # WebDAV authentication type; default Digest
 define("BAIKAL_DAV_AUTH_TYPE", "Digest");
-
-# Baïkal Web Admin ON/OFF switch; default TRUE
-define("BAIKAL_ADMIN_ENABLED", TRUE);
-
-# Baïkal Web Admin autolock ON/OFF switch; default FALSE
-define("BAIKAL_ADMIN_AUTOLOCKENABLED", FALSE);
 
 # Baïkal Web admin password hash; Set via Baïkal Web Admin
 define("BAIKAL_ADMIN_PASSWORDHASH", "");

--- a/Core/Frameworks/BaikalAdmin/Controller/Install/Database.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/Install/Database.php
@@ -60,8 +60,6 @@ class Database extends \Flake\Core\Controller {
 		
 		if($this->oForm->persisted()) {
 			
-			\BaikalAdmin\Core\Auth::lockInstall();
-
 			$sMessage = "<p>Baïkal is now installed, and it's database properly configured. <strong>For security reasons, this installation wizard is now disabled.</strong></p>";
 			$sMessage . "<p>&nbsp;</p>";
 			$sMessage .= "<p><a class='btn btn-success' href='" . PROJECT_URI . "admin/'>Start using Baïkal</a></p>";

--- a/Core/Frameworks/BaikalAdmin/Core/Auth.php
+++ b/Core/Frameworks/BaikalAdmin/Core/Auth.php
@@ -27,55 +27,6 @@
 namespace BaikalAdmin\Core;
 
 class Auth {
-	public static function assertEnabled() {
-		if(!defined("BAIKAL_ADMIN_ENABLED") || BAIKAL_ADMIN_ENABLED !== TRUE) {
-			die("<h1>Ba&iuml;kal Admin is disabled.</h1>To enable it, set BAIKAL_ADMIN_ENABLED to TRUE in <b>Specific/config.php</b>");
-		}
-		
-		self::assertUnlocked();
-	}
-	
-	public static function assertUnlocked() {
-
-		if(defined("BAIKAL_CONTEXT_INSTALL") && BAIKAL_CONTEXT_INSTALL === TRUE) {
-			$sToolName = "Ba&iuml;kal Install Tool";
-			$sFileName = "ENABLE_INSTALL";
-		} else {
-			if(!defined("BAIKAL_ADMIN_AUTOLOCKENABLED") || BAIKAL_ADMIN_AUTOLOCKENABLED === FALSE) {
-				return TRUE;
-			}
-
-			$sToolName = "Ba&iuml;kal Admin";
-			$sFileName = "ENABLE_ADMIN";
-		}
-
-		$sEnableFile = PROJECT_PATH_SPECIFIC . $sFileName;
-		
-		$bLocked = TRUE;
-		if(file_exists($sEnableFile)) {
-
-			clearstatcache();
-			$iTime = intval(filemtime($sEnableFile));
-			if((time() - $iTime) < 3600) {
-				# file has been created/updated less than an hour ago; update it's mtime
-				if(is_writable($sEnableFile)) {
-					@file_put_contents($sEnableFile, '');
-				}
-				$bLocked = FALSE;
-			} else {
-				// file has been created more than an hour ago
-				// delete and declare locked
-				if(!@unlink($sEnableFile)) {
-					die("<h1>" . $sToolName . " is locked.</h1>To unlock it, create (or re-create if it exists already) an empty file named <strong>" . $sFileName . "</strong> (uppercase, no file extension) in the <b>Specific/</b> folder of Ba&iuml;kal.");
-				}
-			}
-		}
-
-		if($bLocked) {
-			die("<h1>" . $sToolName . " is locked.</h1>To unlock it, create (or re-create if it exists already) an empty file named <strong>" . $sFileName . "</strong> (uppercase, no file extension) in the <b>Specific/</b> folder of Ba&iuml;kal.");
-		}
-	}
-	
 	public static function isAuthenticated() {
 		if(isset($_SESSION["baikaladminauth"]) && $_SESSION["baikaladminauth"] === md5(BAIKAL_ADMIN_PASSWORDHASH)) {
 			return TRUE;
@@ -118,11 +69,4 @@ class Auth {
 		return md5('admin:' . $sAuthRealm . ':' . $sPassword);
 	}
 
-	public static function lockAdmin() {
-		@unlink(PROJECT_PATH_SPECIFIC . "ENABLE_ADMIN");
-	}
-
-	public static function lockInstall() {
-		@unlink(PROJECT_PATH_SPECIFIC . "ENABLE_INSTALL");
-	}
 }

--- a/Core/Frameworks/BaikalAdmin/WWWRoot/index.php
+++ b/Core/Frameworks/BaikalAdmin/WWWRoot/index.php
@@ -53,9 +53,6 @@ require PROJECT_PATH_ROOT . 'vendor/autoload.php';
 # Bootstrap BaikalAdmin
 \BaikalAdmin\Framework::bootstrap();
 
-# Assert that BaikalAdmin is enabled
-\BaikalAdmin\Core\Auth::assertEnabled();
-
 # Create and setup a page object
 $oPage = new \Flake\Controller\Page(BAIKALADMIN_PATH_TEMPLATES . "Page/index.html");
 $oPage->injectHTTPHeaders();

--- a/Core/Frameworks/BaikalAdmin/WWWRoot/install/index.php
+++ b/Core/Frameworks/BaikalAdmin/WWWRoot/install/index.php
@@ -52,9 +52,6 @@ require PROJECT_PATH_ROOT . "vendor/autoload.php";
 # Bootstrap BaikalAdmin
 \BaikalAdmin\Framework::bootstrap();
 
-# Evaluate assertions
-\BaikalAdmin\Core\Auth::assertUnlocked();
-
 # Create and setup a page object
 $oPage = new \Flake\Controller\Page(BAIKALADMIN_PATH_TEMPLATES . "Page/index.html");
 $oPage->injectHTTPHeaders();

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ dist: vendor/autoload.php
 	rm -r $(BUILD_DIR); true
 	mkdir -p $(BUILD_DIR) $(BUILD_DIR)/Specific $(BUILD_DIR)/Specific/db
 	cp -R $(BUILD_FILES) $(BUILD_DIR)
-	touch $(BUILD_DIR)/Specific/ENABLE_INSTALL
 	composer install -d $(BUILD_DIR)
 	rm $(BUILD_DIR)/composer.*
 	cd build; zip -r baikal-$(VERSION).zip baikal/
@@ -25,3 +24,7 @@ vendor/autoload.php: composer.lock
 
 composer.lock: composer.json
 	composer update
+
+clean:
+	# Wipe out all local data, and go back to a clean install
+	rm Specific/config.php Specific/config.system.php Specific/db/db.sqlite; true


### PR DESCRIPTION
Hi @netgusto 

I wanted to discuss this, and in the form of a pull request. I think the features around `ENABLE_INSTALL` and `ENABLE_ADMIN` are not _that_ important for most users, and as an alternative we can recommend a few .htaccess rules that allow people to block access to these tools.

I think it does cause some confusion, and I think baikal is slightly better off without these features.

It was very fast for me (under 10 minutes) to strip this functionality, so if you disagree with this change, I also completely understand. But I thought it would be easier to look at this with an already complete pull request.

I'll keep this PR open for about 7 days so you have time to think about that. After that I'll just merge, but even then we can revert this change.