### PR TITLE
Db validation fix

### DIFF
--- a/Core/Frameworks/BaikalAdmin/Controller/Install/Database.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/Install/Database.php
@@ -78,7 +78,9 @@ class Database extends \Flake\Core\Controller {
 	}
 
 	public function validateConnection($oForm, $oMorpho) {
-
+		if($oForm->refreshed()){
+			return TRUE;
+		}
 		$bMySQLEnabled = $oMorpho->element("PROJECT_DB_MYSQL")->value();
 
 		if($bMySQLEnabled) {

--- a/Core/Frameworks/BaikalAdmin/Controller/Settings/System.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/Settings/System.php
@@ -80,6 +80,9 @@ class System extends \Flake\Core\Controller {
 	}
 	
 	public function validationHook(\Formal\Form $oForm, \Formal\Form\Morphology $oMorpho) {
+		if($oForm->refreshed()){
+			return TRUE;
+		}
 		if(intval($oForm->modelInstance()->get("PROJECT_DB_MYSQL")) === 1) {
 				
 			# We have to check the MySQL connection


### PR DESCRIPTION
This should fix the Issue occuring in Installation DB Settings and System Database Settings,
where the Mysql or Sqlite Connections are validated, even if the Form is just refreshed, because MySQL Checkbox was selected.