### PR TITLE
Fix installation, Flake used to init PDO before the db was configured.

### DIFF
--- a/Core/Frameworks/Baikal/Model/Config/Database.php
+++ b/Core/Frameworks/Baikal/Model/Config/Database.php
@@ -29,6 +29,10 @@ namespace Baikal\Model\Config;
 class Database extends \Baikal\Model\Config {
 	
 	protected $aConstants = array(
+		"PROJECT_DB_CONFIGURED" => array(
+			"type" => "boolean",
+			"comment" => "Indicates whether a valid datavase configuration is given and a connection attempt should be made"
+		),
 		"PROJECT_SQLITE_FILE" => array(
 			"type" => "litteral",
 			"comment" => "Define path to Baïkal Database SQLite file",
@@ -57,6 +61,7 @@ class Database extends \Baikal\Model\Config {
 	
 	# Default values
 	protected $aData = array(
+		"PROJECT_DB_CONFIGURED" => FALSE,
 		"PROJECT_SQLITE_FILE" => 'PROJECT_PATH_SPECIFIC . "db/db.sqlite"',
 		"PROJECT_DB_MYSQL" => FALSE,
 		"PROJECT_DB_MYSQL_HOST" => "",

--- a/Core/Frameworks/Baikal/Model/Config/Database.php
+++ b/Core/Frameworks/Baikal/Model/Config/Database.php
@@ -31,7 +31,7 @@ class Database extends \Baikal\Model\Config {
 	protected $aConstants = array(
 		"PROJECT_DB_CONFIGURED" => array(
 			"type" => "boolean",
-			"comment" => "Indicates whether a valid datavase configuration is given and a connection attempt should be made"
+			"comment" => "Indicates whether a valid database configuration is given and a connection attempt should be made"
 		),
 		"PROJECT_SQLITE_FILE" => array(
 			"type" => "litteral",

--- a/Core/Frameworks/Baikal/Model/Config/System.php
+++ b/Core/Frameworks/Baikal/Model/Config/System.php
@@ -45,6 +45,10 @@ class System extends \Baikal\Model\Config {
 			"type" => "litteral",
 			"comment" => 'Should begin and end with a "/"',
 		),
+		"PROJECT_DB_CONFIGURED" => array(
+			"type" => "boolean",
+			"comment" => "Indicates whether a valid datavase configuration is given and a connection attempt should be made"
+		),
 		"PROJECT_SQLITE_FILE" => array(
 			"type" => "litteral",
 			"comment" => "Define path to Baïkal Database SQLite file",
@@ -85,6 +89,7 @@ class System extends \Baikal\Model\Config {
 		"BAIKAL_CARD_BASEURI" => 'PROJECT_BASEURI . "card.php/"',
 		"BAIKAL_CAL_BASEURI" => 'PROJECT_BASEURI . "cal.php/"',
 		"BAIKAL_DAV_BASEURI" => 'PROJECT_BASEURI . "dav.php/"',
+		"PROJECT_DB_CONFIGURED" => FALSE,
 		"PROJECT_SQLITE_FILE" => 'PROJECT_PATH_SPECIFIC . "db/db.sqlite"',
 		"PROJECT_DB_MYSQL" => FALSE,
 		"PROJECT_DB_MYSQL_HOST" => "",
@@ -209,6 +214,9 @@ define("BAIKAL_CAL_BASEURI", PROJECT_BASEURI . "cal.php/");
 
 # Should begin and end with a "/"
 define("BAIKAL_DAV_BASEURI", PROJECT_BASEURI . "dav.php/");
+
+# Indicates whether a valid datavase configuration is given and a connection attempt should be made
+define("PROJECT_DB_CONFIGURED", FALSE);
 
 # Define path to Baïkal Database SQLite file
 define("PROJECT_SQLITE_FILE", PROJECT_PATH_SPECIFIC . "db/db.sqlite");

--- a/Core/Frameworks/Baikal/Model/Config/System.php
+++ b/Core/Frameworks/Baikal/Model/Config/System.php
@@ -47,7 +47,7 @@ class System extends \Baikal\Model\Config {
 		),
 		"PROJECT_DB_CONFIGURED" => array(
 			"type" => "boolean",
-			"comment" => "Indicates whether a valid datavase configuration is given and a connection attempt should be made"
+			"comment" => "Indicates whether a valid database configuration is given and a connection attempt should be made"
 		),
 		"PROJECT_SQLITE_FILE" => array(
 			"type" => "litteral",
@@ -215,7 +215,7 @@ define("BAIKAL_CAL_BASEURI", PROJECT_BASEURI . "cal.php/");
 # Should begin and end with a "/"
 define("BAIKAL_DAV_BASEURI", PROJECT_BASEURI . "dav.php/");
 
-# Indicates whether a valid datavase configuration is given and a connection attempt should be made
+# Indicates whether a valid database configuration is given and a connection attempt should be made
 define("PROJECT_DB_CONFIGURED", FALSE);
 
 # Define path to Baïkal Database SQLite file

--- a/Core/Frameworks/BaikalAdmin/Controller/Install/Database.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/Install/Database.php
@@ -45,8 +45,6 @@ class Database extends \Flake\Core\Controller {
 			$this->oForm->execute();
 			
 			if($this->oForm->persisted()) {
-
-				# nothing here
 				$this->oModel->set("PROJECT_DB_CONFIGURED", TRUE);
 				$this->oModel->persist();
 			}

--- a/Core/Frameworks/BaikalAdmin/Controller/Install/Database.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/Install/Database.php
@@ -47,6 +47,8 @@ class Database extends \Flake\Core\Controller {
 			if($this->oForm->persisted()) {
 
 				# nothing here
+				$this->oModel->set("PROJECT_DB_CONFIGURED", TRUE);
+				$this->oModel->persist();
 			}
 		}
 	}

--- a/Core/Frameworks/Flake/Framework.php
+++ b/Core/Frameworks/Flake/Framework.php
@@ -225,10 +225,12 @@ class Framework extends \Flake\Core\Framework {
 	
 	protected static function initDb() {
 
-		if(defined("PROJECT_DB_MYSQL") && PROJECT_DB_MYSQL === TRUE) {
-			self::initDbMysql();
-		} else {
-			self::initDbSqlite();
+		if(defined("PROJECT_DB_CONFIGURED") && PROJECT_DB_CONFIGURED === TRUE) {
+			if(defined("PROJECT_DB_MYSQL") && PROJECT_DB_MYSQL === TRUE) {
+				self::initDbMysql();
+			} else {
+				self::initDbSqlite();
+			}
 		}
 	}
 	


### PR DESCRIPTION
I wasn't able to install Baikal with MySQL, this is my attempt to fix it. Works on my system, however, neither do I know any php nor do I know whether the introduction of a new config entry would be the prefered way to fix it.

I setup php to load pdo_mysql but not pdo_sqlite. The first installation step works fine, however, when the Database setup page is requested, `Flake` finds the Database variables (at this stage empty, and indicating sqlite) in `config.system.php`. Because the Sqlite backend isn't loaded, it tries to connect to a MySQL server using empty host/database/user/password, which causes PDO to throw an exception (domain changed to example.com in the log):

```
2016/03/10 18:49:11 [error] 10794#0: *2036 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Uncaught PDOException: SQLSTATE[HY000] [2002] No such file or directory in /usr/share/webapps/baikal/Core/Frameworks/Flake/Core/Database/Mysql.php:49
Stack trace:
#0 /usr/share/webapps/baikal/Core/Frameworks/Flake/Core/Database/Mysql.php(49): PDO->__construct('mysql:host=;dbn...', '', '')
#1 /usr/share/webapps/baikal/Core/Frameworks/Flake/Framework.php(281): Flake\Core\Database\Mysql->__construct('', '', '', '')
#2 /usr/share/webapps/baikal/Core/Frameworks/Flake/Framework.php(229): Flake\Framework::initDbMysql()
#3 /usr/share/webapps/baikal/Core/Frameworks/Flake/Framework.php(223): Flake\Framework::initDb()
#4 /usr/share/webapps/baikal/html/admin/install/index.php(50): Flake\Framework::bootstrap()
#5 {main}
  thrown in /usr/share/webapps/baikal/Core/Frameworks/Flake/Core/Database/Mysql.php on line 49" while reading response header from upstream, client: 150.214.9.251, server: dav.example.com, request: "GET /admin/install/?/database HTTP/1.1", upstream: "fastcgi://unix:/run/php-fpm/php-fpm.sock:", host: "dav.example.com", referrer: "https://dav.example.com/admin/install/"
```
