### PR TITLE
Add CSRF protection

### DIFF
--- a/Core/Frameworks/BaikalAdmin/WWWRoot/index.php
+++ b/Core/Frameworks/BaikalAdmin/WWWRoot/index.php
@@ -25,7 +25,6 @@
 ***************************************************************/
 
 ini_set("session.cookie_httponly", 1);
-ini_set("display_errors", 0);
 ini_set("log_errors", 1);
 error_reporting(E_ALL);
 
@@ -60,14 +59,28 @@ $oPage->injectHTTPHeaders();
 $oPage->setTitle("Baïkal " . BAIKAL_VERSION . " Web Admin");
 $oPage->setBaseUrl(PROJECT_URI);
 
-# Authentication
-if (
-    \BaikalAdmin\Core\Auth::isAuthenticated() === false &&
-    \BaikalAdmin\Core\Auth::authenticate() === false
-) {
-    $oPage->zone("navbar")->addBlock(new \BaikalAdmin\Controller\Navigation\Topbar\Anonymous());
-    $oPage->zone("Payload")->addBlock(new \BaikalAdmin\Controller\Login());
+if (! \BaikalAdmin\Core\Auth::isAuthenticated()) {
+    if (\BaikalAdmin\Core\Auth::authenticate()) {
+        // Redirect to itself
+        header('Location: ' . $_SERVER['REQUEST_URI']);
+
+    } else {
+        // Draw login page
+        $oPage->zone("navbar")->addBlock(new \BaikalAdmin\Controller\Navigation\Topbar\Anonymous());
+        $oPage->zone("Payload")->addBlock(new \BaikalAdmin\Controller\Login());
+    }
 } else {
+
+    // CSRF token check
+    if ($_SERVER['REQUEST_METHOD']==='POST') {
+        if (!isset($_POST['CSRF_TOKEN'])) {
+            throw new \Exception('CSRF token was not submitted. Try removing your cookies and log in again');
+        }
+        if ($_POST['CSRF_TOKEN'] !== $_SESSION['CSRF_TOKEN']) {
+            throw new \Exception('CSRF token did not match the session CSRF token. Please try to do this action again.');
+        }
+    }
+
     $oPage->zone("navbar")->addBlock(new \BaikalAdmin\Controller\Navigation\Topbar());
 
     # Route the request

--- a/Core/Frameworks/BaikalAdmin/WWWRoot/index.php
+++ b/Core/Frameworks/BaikalAdmin/WWWRoot/index.php
@@ -72,7 +72,7 @@ if (! \BaikalAdmin\Core\Auth::isAuthenticated()) {
 } else {
 
     // CSRF token check
-    if ($_SERVER['REQUEST_METHOD']==='POST') {
+    if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if (!isset($_POST['CSRF_TOKEN'])) {
             throw new \Exception('CSRF token was not submitted. Try removing your cookies and log in again');
         }

--- a/Core/Frameworks/Flake/Framework.php
+++ b/Core/Frameworks/Flake/Framework.php
@@ -190,6 +190,9 @@ class Framework extends \Flake\Core\Framework {
         if (!\Flake\Util\Tools::isCliPhp()) {
             ini_set("html_errors", true);
             session_start();
+            if (!isset($_SESSION['CSRF_TOKEN'])) {
+                $_SESSION['CSRF_TOKEN'] = bin2hex(openssl_random_pseudo_bytes(20));
+            }
         }
 
         setlocale(LC_ALL, FLAKE_LOCALE);

--- a/Core/Frameworks/Flake/Framework.php
+++ b/Core/Frameworks/Flake/Framework.php
@@ -193,6 +193,7 @@ class Framework extends \Flake\Core\Framework {
             if (!isset($_SESSION['CSRF_TOKEN'])) {
                 $_SESSION['CSRF_TOKEN'] = bin2hex(openssl_random_pseudo_bytes(20));
             }
+
         }
 
         setlocale(LC_ALL, FLAKE_LOCALE);

--- a/Core/Frameworks/Formal/Form.php
+++ b/Core/Frameworks/Formal/Form.php
@@ -394,21 +394,27 @@ class Form {
             $sCloseButton = "";
         }
 
+        if (!isset($_SESSION['CSRF_TOKEN'])) {
+            throw new \LogicException('A CSRF token must be set in the session. Try clearing your cookies and logging in again');
+        }
+        $csrfToken = htmlspecialchars($_SESSION['CSRF_TOKEN']);
+
         $sActionUrl = $this->option("action");
 
         $sHtml = <<<HTML
 <form class="form-horizontal" action="{$sActionUrl}" method="post" enctype="multipart/formdata">
-	<input type="hidden" name="{$sSubmittedFlagName}" value="1" />
-	<input type="hidden" name="refreshed" value="0" />
-	<fieldset>
-		<legend style="line-height: 40px;">{$this->sDisplayTitle}</legend>
-		{$this->sDisplayMessage}
-		{$elements}
-		<div class="form-actions">
-			<button type="submit" class="btn btn-primary">Save changes</button>
-			{$sCloseButton}
-		</div>
-	</fieldset>
+    <input type="hidden" name="{$sSubmittedFlagName}" value="1" />
+    <input type="hidden" name="refreshed" value="0" />
+    <input type="hidden" name="csrf-token" value="{$csrfToken}" />
+    <fieldset>
+        <legend style="line-height: 40px;">{$this->sDisplayTitle}</legend>
+        {$this->sDisplayMessage}
+        {$elements}
+        <div class="form-actions">
+            <button type="submit" class="btn btn-primary">Save changes</button>
+            {$sCloseButton}
+        </div>
+    </fieldset>
 </form>
 HTML;
 

--- a/Core/Frameworks/Formal/Form.php
+++ b/Core/Frameworks/Formal/Form.php
@@ -405,7 +405,7 @@ class Form {
 <form class="form-horizontal" action="{$sActionUrl}" method="post" enctype="multipart/formdata">
     <input type="hidden" name="{$sSubmittedFlagName}" value="1" />
     <input type="hidden" name="refreshed" value="0" />
-    <input type="hidden" name="csrf-token" value="{$csrfToken}" />
+    <input type="hidden" name="CSRF_TOKEN" value="{$csrfToken}" />
     <fieldset>
         <legend style="line-height: 40px;">{$this->sDisplayTitle}</legend>
         {$this->sDisplayMessage}


### PR DESCRIPTION
This PR adds a CSRF token to the session and every form.

Upon submission the CSRF token is validated and the request is denied if this is not the case. This might not be done in the best possible place, but the Flake framework unfortunately violates all sorts of best practices that make it hard for me to figure out exactly what the proper place to do this is.

In the future I think I would like to replace it with Slim or Silex.

This fixes #182