### PR TITLE
db bugfixes

### DIFF
--- a/Core/Frameworks/BaikalAdmin/Controller/Settings/System.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/Settings/System.php
@@ -129,6 +129,13 @@ class System extends \Flake\Core\Controller {
                 // We'll have to clean this up later.
                 $sFile = eval('return ' . $sFile . ';');
 
+                if (!file_exists($sFile)) {
+                    $sMessage = "DB file does not exist.";
+                    $sMessage .= "</br>You can copy a sqlite Database file from there: <strong>Core/Resources/Db/SQLite/db.sqlite</strong>";
+                    $oForm->declareError($oMorpho->element("PROJECT_SQLITE_FILE"), $sMessage);
+                    return;
+                }
+
                 # Asserting DB file is writable
                 if (file_exists($sFile) && !is_writable($sFile)) {
                     $sMessage = "DB file is not writable. Please give write permissions on file <span style='font-family: monospace'>" . $sFile . "</span>";

--- a/Core/Frameworks/Flake/Framework.php
+++ b/Core/Frameworks/Flake/Framework.php
@@ -230,7 +230,7 @@ class Framework extends \Flake\Core\Framework {
 
     protected static function initDb() {
         # Dont init db on install, but in normal mode and when upgrading
-        if (defined("BAIKAL_CONTEXT_INSTALL") && (BAIKAL_CONFIGURED_VERSION === BAIKAL_VERSION)) {
+        if (defined("BAIKAL_CONTEXT_INSTALL") && (!defined("BAIKAL_CONFIGURED_VERSION") || BAIKAL_CONFIGURED_VERSION === BAIKAL_VERSION)) {
             return true;
         }
         if (defined("PROJECT_DB_MYSQL") && PROJECT_DB_MYSQL === true) {


### PR DESCRIPTION
this fixes 2 bugs:
- creation of empty sqlite file by system settings, if file does not
exist, but dir is writable
- php warning at install, cause configured version is not defined at the
very start #509 