### PR TITLE
MySQL date types can't save dates before Unix epoch

### DIFF
--- a/Core/Resources/Db/MySQL/db.sql
+++ b/Core/Resources/Db/MySQL/db.sql
@@ -35,8 +35,8 @@ CREATE TABLE calendarobjects (
     etag VARBINARY(32),
     size INT(11) UNSIGNED NOT NULL,
     componenttype VARBINARY(8),
-    firstoccurence INT(11) UNSIGNED,
-    lastoccurence INT(11) UNSIGNED,
+    firstoccurence BIGINT(20),
+    lastoccurence BIGINT(20),
     uid VARBINARY(200),
     UNIQUE(calendarid, uri)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
When a client wants to sync dates before 1-1-1970 (for example birthdays), the server response with:

```
<?xml` version="1.0" encoding="utf-8"?>
<d:error xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
  <s:sabredav-version>3.1.2</s:sabredav-version>
  <s:exception>PDOException</s:exception>
  <s:message>SQLSTATE[22003]: Numeric value out of range: 1264 Out of range value for column 'firstoccurence' at row 1</s:message>
</d:error>
```

Original unsigned int (11) can't store dates before 1-1-1970 (Unix Epoch)