### PR TITLE
baikal-server.com just redirects to sabre.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@ Baïkal
 
 This is the source repository for the Baïkal CalDAV and CardDAV server.
 
-* Go to [baikal-server.com][1] to get more information about this project.
-* Head to [sabre.io/baikal][2] for information about installation, upgrading
-  and troubleshooting.
+Head to [sabre.io/baikal][2] for information about installation, upgrading and troubleshooting.
 
 Upgrading from 0.2.7
 --------------------
@@ -20,7 +18,6 @@ Credits
 Bäikal is developed by [Jérôme Schneider][3] from [Net Gusto][3] and [fruux][4].
 Many thanks to Daniel Aleksandersen (@zcode) for greatly improving the quality of the project page (http://baikal-server.com).
 
-[1]: http://baikal-server.com/
 [2]: http://sabre.io/baikal/
 [3]: http://netgusto.com/
 [4]: https://fruux.com/


### PR DESCRIPTION
The link to baikal-server.com doesn't make any sense anymore as it is just a redirect to sabre.io.