### PR TITLE
Add calendar sharing support

### DIFF
--- a/Core/Frameworks/Baikal/Core/Server.php
+++ b/Core/Frameworks/Baikal/Core/Server.php
@@ -169,6 +169,8 @@ class Server {
             $this->server->addPlugin(new \Sabre\CalDAV\Plugin());
             $this->server->addPlugin(new \Sabre\CalDAV\ICSExportPlugin());
             $this->server->addPlugin(new \Sabre\CalDAV\Schedule\Plugin());
+            $this->server->addPlugin(new \Sabre\DAV\Sharing\Plugin());
+            $this->server->addPlugin(new \Sabre\CalDAV\SharingPlugin());
         }
         if ($this->enableCardDAV) {
             $this->server->addPlugin(new \Sabre\CardDAV\Plugin());

--- a/Core/Frameworks/Baikal/Model/Calendar.php
+++ b/Core/Frameworks/Baikal/Model/Calendar.php
@@ -28,7 +28,7 @@
 namespace Baikal\Model;
 
 class Calendar extends \Flake\Core\Model\Db {
-    const DATATABLE = "calendars";
+    const DATATABLE = "calendarinstances";
     const PRIMARYKEY = "id";
     const LABELFIELD = "displayname";
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php"           : ">=5.5",
-        "sabre/dav"     : "~3.1.2",
+        "sabre/dav"     : "~3.2.0",
         "twig/twig"     : "~1.8.0"
     },
     "require-dev" : {


### PR DESCRIPTION
Hi, this is a very basic change to default to sabre/dav 3.2.0 and add support for sharing calendars. 
There is more information on the upgrade path to 3.2.0 here:
http://sabre.io/dav/upgrade/3.1-to-3.2/
After a quick look I found that the database migration was enough, and iCal agreed to share my calendar. Unfortunately I am new to this codebase so I cannot tell if this introduces any regression.