### PR TITLE
Add Http authentication

### DIFF
--- a/Core/Frameworks/Baikal/Core/Server.php
+++ b/Core/Frameworks/Baikal/Core/Server.php
@@ -133,8 +133,8 @@ class Server {
 
         if ($this->authType === 'Basic') {
             $authBackend = new \Baikal\Core\PDOBasicAuth($this->pdo, $this->authRealm);
-	} elseif ($this->authType === 'Http') {
-	    $authBackend = new \Sabre\DAV\Auth\Backend\Apache();
+        } elseif ($this->authType === 'Http') {
+            $authBackend = new \Sabre\DAV\Auth\Backend\Apache();
         } else {
             $authBackend = new \Sabre\DAV\Auth\Backend\PDO($this->pdo);
             $authBackend->setRealm($this->authRealm);

--- a/Core/Frameworks/Baikal/Core/Server.php
+++ b/Core/Frameworks/Baikal/Core/Server.php
@@ -133,6 +133,8 @@ class Server {
 
         if ($this->authType === 'Basic') {
             $authBackend = new \Baikal\Core\PDOBasicAuth($this->pdo, $this->authRealm);
+	} elseif ($this->authType === 'Http') {
+	    $authBackend = new \Sabre\DAV\Auth\Backend\Apache();
         } else {
             $authBackend = new \Sabre\DAV\Auth\Backend\PDO($this->pdo);
             $authBackend->setRealm($this->authRealm);

--- a/Core/Frameworks/Baikal/Model/Config/Standard.php
+++ b/Core/Frameworks/Baikal/Model/Config/Standard.php
@@ -85,7 +85,7 @@ class Standard extends \Baikal\Model\Config {
         $oMorpho->add(new \Formal\Element\Listbox([
             "prop"    => "BAIKAL_DAV_AUTH_TYPE",
             "label"   => "WebDAV authentication type",
-            "options" => ["Digest", "Basic"]
+            "options" => ["Digest", "Basic", "Http"]
         ]));
 
         $oMorpho->add(new \Formal\Element\Password([


### PR DESCRIPTION
Sabre seems to be able to reuse a previous Http authentication (made
by the HTTP server) with the Apache Auth Plugin. This PR should add
this authentication method into Baikal (tested on my own server).

A configuration option has also been added to the Basic and Digest methods.