### PR TITLE
Fix for determining PROJECT_BASEURI

### DIFF
--- a/Core/Frameworks/Flake/Framework.php
+++ b/Core/Frameworks/Flake/Framework.php
@@ -158,7 +158,7 @@ class Framework extends \Flake\Core\Framework {
         define("PROJECT_PATH_DOCUMENTROOT", PROJECT_PATH_ROOT . "html/");
 
         # Determine PROJECT_BASEURI
-        $sScript = substr($_SERVER["SCRIPT_FILENAME"], strlen($_SERVER["DOCUMENT_ROOT"]));
+        $sScript = $_SERVER["SCRIPT_NAME"];
         $sDirName = str_replace("\\", "/", dirname($sScript));    # fix windows backslashes
 
         if ($sDirName !== ".") {


### PR DESCRIPTION
See https://github.com/fruux/Baikal/issues/634: when the Baikal
installation resides outside the DOCUMENT_ROOT, the PROJECT_BASEURI
variable is miscalculated. Use SCRIPT_NAME instead of subtracting
the length of DOCUMENT_ROOT from SCRIPT_FILENAME.